### PR TITLE
fixed new lines and tabs in zkmorph.sh & make it work on OS X

### DIFF
--- a/bin/zkmorph.sh
+++ b/bin/zkmorph.sh
@@ -33,6 +33,6 @@ echo "writing to "$3
 
 echo "<indexer table=\""$1"\" mapper=\"com.ngdata.hbaseindexer.morphline.MorphlineResultToSolrMapper\" read-row=\"never\">" > $3
 echo "  <param name=\"morphlineString\" value=\"" >> $3
-cat $2 | sed 's/\&/&#038;/g' | sed 's/\"/\&quot;/g' | sed 's/</\&lt;/g' | sed 's/>/\&gt;/g' | sed ':a;N;$!ba;s/\n/\&#10;\n/g' >> $3
+cat $2 | sed 's/\&/\&#38;/g;s/\"/\&quot;/g;s/</\&lt;/g;s/>/\&gt;/g;s/\t/\&#9;/g' | sed -e ':a' -e 'N' -e '$!ba' -e 's/\n/\&#10;/g' >> $3
 echo "\"/>" >> $3
 echo "</indexer>" >> $3


### PR DESCRIPTION
When reading XML, all white characters are replaced by space. And originally new line was replaced by `&#10;\n` so after read it was translated to "\n " (note the space after new line). Now it is replaced only by `&#10;` which works correctly.

Support for \t was added as well.

`sed ':a;N;$!ba;s/\n/\&#10;\n/g'` doesn't work on OS X so it was rewritten to platform independent way.

Multiple seds was merged into one to minor speedup.
